### PR TITLE
Fix hardcoded buffer age that was causing static UI elements to not render on first frame

### DIFF
--- a/spell-framework/src/skia_non_docs.rs
+++ b/spell-framework/src/skia_non_docs.rs
@@ -29,6 +29,9 @@ pub struct SkiaSoftwareBufferReal {
     pub primary_slot: RefCell<Slot>,
     pub pool: Rc<RefCell<SlotPool>>,
     pub last_dirty_region: RefCell<Option<DirtyRegion>>,
+    /// Buffer age for partial rendering. 0 means the buffer is new and
+    /// requires a full redraw; 1 means reuse from the previous frame.
+    pub age: Cell<u8>,
 }
 
 impl SkiaSoftwareBufferReal {
@@ -40,6 +43,8 @@ impl SkiaSoftwareBufferReal {
             .create_buffer(width, height, stride, wl_shm::Format::Argb8888)
             .unwrap();
         *self.primary_slot.borrow_mut() = buffer.slot();
+        // New buffer has no prior content; force a full redraw.
+        self.age.set(0);
         buffer
     }
 }
@@ -91,14 +96,17 @@ impl RenderBuffer for SkiaSoftwareBufferReal {
         // };
 
         // let bytes = bytemuck::cast_slice_mut(&mut native_buffer);
+        let age = self.age.get();
         *self.last_dirty_region.borrow_mut() = render_callback(
             width,
             height,
             skia_safe::ColorType::BGRA8888,
-            1,
+            age,
             self.primary_slot.borrow_mut().canvas(pool).unwrap(),
         )
         .unwrap();
+        // After the first full render, subsequent frames can use partial rendering.
+        self.age.set(1);
         Ok(())
     }
 }
@@ -174,6 +182,7 @@ impl SpellSkiaWinAdapterReal {
             primary_slot,
             pool,
             last_dirty_region: Default::default(),
+            age: Cell::new(0),
         });
         let renderer = SkiaRenderer::new_with_surface(
             &SkiaSharedContext::default(),
@@ -215,8 +224,8 @@ impl SpellSkiaWinAdapterReal {
     }
 
     pub(crate) fn changed_scale_factor(&self, scale: u32) -> (Buffer, u32, u32, f32) {
-        let width: u32 = (self.size.get().width * scale + 60) / 120;
-        let height: u32 = (self.size.get().height * scale + 60) / 120;
+        let width: u32 = (self.size_original.get().width * scale + 60) / 120;
+        let height: u32 = (self.size_original.get().height * scale + 60) / 120;
         let scale_factor: f32 = scale as f32 / 120.0;
         self.scale_factor.set(scale_factor);
         self.size.set(PhysicalSize { width, height });

--- a/spell-framework/src/wayland_adapter.rs
+++ b/spell-framework/src/wayland_adapter.rs
@@ -660,19 +660,13 @@ impl FractionalScaleHandler for SpellWin {
     fn preferred_scale(
         &mut self,
         _: &Connection,
-        _: &QueueHandle<Self>,
+        qh: &QueueHandle<Self>,
         _: &wl_surface::WlSurface,
         scale: u32,
     ) {
         info!("Scale factor changed, invoked from custom trait. {}", scale);
         let width_old = self.adapter.size_original.get().width;
         let height_old = self.adapter.size_original.get().height;
-        self.layer.as_ref().unwrap().wl_surface().damage_buffer(
-            0,
-            0,
-            self.adapter.size.get().width as i32,
-            self.adapter.size.get().height as i32,
-        );
         let (buffer, width, height, scale_factor) = self.adapter.changed_scale_factor(scale);
         self.config.width = width;
         self.config.height = height;
@@ -692,8 +686,11 @@ impl FractionalScaleHandler for SpellWin {
             .as_ref()
             .unwrap()
             .set_destination(width_old as i32, height_old as i32);
-        self.adapter.request_redraw();
-        self.layer.as_ref().unwrap().commit();
+
+        // Force a full render-damage-attach cycle so the newly scaled buffer
+        // is actually presented to the compositor on this commit.
+        self.first_configure.set(true);
+        self.converter(qh);
     }
 }
 


### PR DESCRIPTION
# Abstract

Three related bugs in `spell-framework` cause static Slint elements (such as `Image` components) to fail to render when displayed through Spell's Wayland pipeline, even though they render correctly in `slint-viewer`. The root cause is a hardcoded buffer age parameter in the Skia software rendering bridge that tells Slint's partial renderer to skip the initial full redraw. Two additional bugs in the fractional scaling path compound the issue.

## Reproduction

Any Slint component with a static `Image` element will fail to render the image through Spell, while dynamic elements (like a `Text` bound to a timer-updated property) render fine. For example, the `TopBar` component in `spell-demo` renders a centered cyan clock but the Artix Linux SVG icon in the top-left corner is invisible:

**Through Spell (`cargo run -p spell-demo --bin bar`):**

<img width="1438" height="77" alt="image" src="https://github.com/user-attachments/assets/fdff190b-c298-4186-80b9-2caa95038424" />

Only the clock is visible — the icon does not render.

**Through `slint-viewer ./spell-demo/ui/app-window.slint`:**

<img width="1650" height="102" alt="image" src="https://github.com/user-attachments/assets/bc78ebf9-21f1-47c5-9d3c-a6aa0df3d589" />

Both the icon and the clock render correctly.

## Root Cause

### Bug 1: Hardcoded `age = 1` in `SkiaSoftwareBufferReal::with_buffer` (principal cause)

In  `spell-framework/src/skia_non_docs.rs`, the `RenderBuffer::with_buffer` implementation passes a hardcoded `age` of `1` to Slint's Skia `render_callback`:

```rust
*self.last_dirty_region.borrow_mut() = render_callback(
    width,
    height,
    skia_safe::ColorType::BGRA8888,
    1,  // <-- always 1, even on the first frame
    self.primary_slot.borrow_mut().canvas(pool).unwrap(),
)
.unwrap();
```

Slint's Skia renderer has `use_partial_rendering() -> true`, meaning the `age` parameter controls whether it performs a full redraw or only renders dirty regions:

- `age = 0` → buffer is new, render **everything**
- `age = 1` → buffer contains valid content from the previous frame, only render what **changed**

On the very first render call, the buffer is uninitialized — there is no "previous frame." But `age = 1` tells the renderer the buffer already has valid content, so it only renders regions marked as dirty. Static elements like images are only dirty on initialization, and with the wrong age, the renderer skips them entirely. Dynamic elements (like the clock text updated by a `Timer`) continuously mark their regions dirty, so they always render.

For reference, Slint's own `softbuffer`-backed implementation correctly uses `target_buffer.age()` from the graphics system rather than a hardcoded value ([`software_surface.rs` in slint-ui/slint](https://github.com/slint-ui/slint/blob/master/internal/renderers/skia/software_surface.rs)).

The commented-out code in the same file shows this was once understood:

```rust
// let mut age = 1;
// let pixels = shared_pixel_buffer.get_or_insert_with(|| {
//     age = 0;
//     SharedPixelBuffer::new(width.get(), height.get())
// });
```

### Bug 2: Fractional scale compounding in `changed_scale_factor`

In `spell-framework/src/skia_non_docs.rs`, the `changed_scale_factor` method computes new physical dimensions from `self.size` (the current, already-scaled physical size) instead of `self.size_original` (the initial logical size):

```rust
let width: u32 = (self.size.get().width * scale + 60) / 120;
let height: u32 = (self.size.get().height * scale + 60) / 120;
```
Since the method also writes back to `self.size`, any subsequent call to `preferred_scale` (which is valid — compositors can re-advertise scale when monitors change) compounds the scaling: each call multiplies the already-scaled dimensions by the scale factor again, causing the buffer to grow uncontrollably.

### Bug 3: `preferred_scale` commits surface without attaching the new buffer

In `spell-framework/src/wayland_adapter.rs`, the `FractionalScaleHandler::preferred_scale` implementation reallocates the buffer at the new scaled dimensions and configures the viewporter, but then only calls `request_redraw()` + `commit()` without ever calling `damage_buffer()` or `attach()`:

```rust
self.adapter.request_redraw();
self.layer.as_ref().unwrap().commit();
```

This commits the viewporter state change to the compositor without presenting the new buffer content. The compositor receives a surface commit with no buffer attachment — so it either shows the old (wrong-size) buffer or nothing. The actual render + attach only happens on the next `frame` callback in `converter()`, by which point the compositor has already presented a broken frame.

Additionally, the handler called `damage_buffer()` *before* `changed_scale_factor()`, damaging the old buffer dimensions rather than the new ones.

## Fix

The fix touches two files:

**`spell-framework/src/skia_non_docs.rs`:**

1. Added an `age: Cell<u8>` field to `SkiaSoftwareBufferReal`, initialized to `0` (new buffer, full redraw needed).
2. In `with_buffer`, replaced the hardcoded `1` with `self.age.get()`, and set the age to `1` after a successful render so subsequent frames can benefit from partial rendering.
3. In `refresh_buffer`, reset the age to `0` since the newly allocated buffer has no prior content.
4. In `changed_scale_factor`, changed the dimension computation to use `self.size_original` instead of `self.size` to prevent scale compounding on repeated calls.

**`spell-framework/src/wayland_adapter.rs`:**

5. In `preferred_scale`, removed the premature `damage_buffer()` call and the bare `request_redraw()` + `commit()`. Replaced with `self.first_configure.set(true)` followed by `self.converter(qh)`, which performs the full render → damage → attach → frame → commit cycle atomically.
6. Named the previously-unused `qh` parameter so it can be passed to `converter()`.

## Final Words

I am quite excited to see this project, I tried to make something similar not long ago but ended giving up and using `quickshell` instead. 