### PR TITLE
Allow for immediate execution in the event loop

### DIFF
--- a/spell-framework/src/skia_non_docs.rs
+++ b/spell-framework/src/skia_non_docs.rs
@@ -4,6 +4,7 @@ use i_slint_core::{items::MouseCursor, partial_renderer::DirtyRegion, platform::
 
 #[cfg(not(docsrs))]
 use slint::{PhysicalSize, Window};
+use smithay_client_toolkit::reexports::calloop;
 #[cfg(not(docsrs))]
 #[cfg(feature = "i-slint-renderer-skia")]
 use smithay_client_toolkit::{
@@ -15,7 +16,6 @@ use std::{
     cell::RefCell,
     fmt::Debug,
     rc::{Rc, Weak},
-    sync::{Arc, Mutex},
 };
 use tracing::{info, warn};
 
@@ -124,7 +124,7 @@ pub struct SpellSkiaWinAdapterReal {
     pub(crate) needs_redraw: Cell<bool>,
     pub(crate) scale_factor: Cell<f32>,
     #[allow(clippy::type_complexity)]
-    pub(crate) slint_event_proxy: Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>>,
+    pub(crate) slint_event_proxy: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
     pub(crate) current_cursor: Cell<MouseCursor>,
 }
 
@@ -185,7 +185,7 @@ impl SpellSkiaWinAdapterReal {
         primary_slot: RefCell<Slot>,
         width: u32,
         height: u32,
-        slint_proxy: Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>>,
+        slint_proxy: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
     ) -> Rc<Self> {
         let buffer = Rc::new(SkiaSoftwareBufferReal {
             primary_slot,

--- a/spell-framework/src/skia_non_docs.rs
+++ b/spell-framework/src/skia_non_docs.rs
@@ -4,7 +4,6 @@ use i_slint_core::{items::MouseCursor, partial_renderer::DirtyRegion, platform::
 
 #[cfg(not(docsrs))]
 use slint::{PhysicalSize, Window};
-use smithay_client_toolkit::reexports::calloop;
 #[cfg(not(docsrs))]
 #[cfg(feature = "i-slint-renderer-skia")]
 use smithay_client_toolkit::{
@@ -123,8 +122,6 @@ pub struct SpellSkiaWinAdapterReal {
     pub(crate) buffer_slint: Rc<SkiaSoftwareBufferReal>,
     pub(crate) needs_redraw: Cell<bool>,
     pub(crate) scale_factor: Cell<f32>,
-    #[allow(clippy::type_complexity)]
-    pub(crate) slint_event_proxy: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
     pub(crate) current_cursor: Cell<MouseCursor>,
 }
 
@@ -185,7 +182,6 @@ impl SpellSkiaWinAdapterReal {
         primary_slot: RefCell<Slot>,
         width: u32,
         height: u32,
-        slint_proxy: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
     ) -> Rc<Self> {
         let buffer = Rc::new(SkiaSoftwareBufferReal {
             primary_slot,
@@ -204,7 +200,6 @@ impl SpellSkiaWinAdapterReal {
             buffer_slint: buffer,
             scale_factor: Cell::new(1.),
             needs_redraw: Cell::new(true),
-            slint_event_proxy: slint_proxy,
             current_cursor: Cell::new(MouseCursor::Default),
         })
     }

--- a/spell-framework/src/slint_adapter.rs
+++ b/spell-framework/src/slint_adapter.rs
@@ -33,21 +33,35 @@ use crate::dummy_skia_docs::SpellSkiaWinAdapterDummy;
 /// adapter internally uses [Skia](https://skia.org/) 2D graphics library for rendering.
 #[cfg(docsrs)]
 pub type SpellSkiaWinAdapter = SpellSkiaWinAdapterDummy;
+
 /// Previously needed to be implemented, now this struct is called and set internally
 /// when [`invoke_spell`](crate::wayland_adapter::SpellWin::invoke_spell) is called.
 pub struct SpellLayerShell {
     /// Span storing the logging context for `debug`` statements of slint.
     pub span: span::Span,
+    slint_event_sender: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
 }
 
-impl Default for SpellLayerShell {
+impl SpellLayerShell {
     /// Creates an instance of this Platform implementation, for internal use.
-    fn default() -> Self {
-        SpellLayerShell {
+    pub(crate) fn new(
+        slint_event_sender: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
+    ) -> Self {
+        Self {
             span: span!(Level::INFO, "slint-log",),
+            slint_event_sender,
         }
     }
 }
+
+// impl Default for SpellLayerShell {
+//     /// Creates an instance of this Platform implementation, for internal use.
+//     fn default() -> Self {
+//         SpellLayerShell {
+//             span: span!(Level::INFO, "slint-log",),
+//         }
+//     }
+// }
 
 impl Platform for SpellLayerShell {
     fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, slint::PlatformError> {
@@ -66,9 +80,7 @@ impl Platform for SpellLayerShell {
     }
 
     fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
-        Some(Box::new(SlintEventProxy(ADAPTERS.with(|v| {
-            v.borrow().last().unwrap().slint_event_proxy.clone()
-        }))))
+        Some(Box::new(SlintEventProxy(self.slint_event_sender.clone())))
     }
 }
 

--- a/spell-framework/src/slint_adapter.rs
+++ b/spell-framework/src/slint_adapter.rs
@@ -4,12 +4,9 @@
 //! in intial iterations of spell_framework.
 use crate::configure::LayerConf;
 use slint::platform::{EventLoopProxy, Platform, WindowAdapter};
-use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{Arc, Mutex},
-};
-use tracing::{Level, info, span, warn};
+use smithay_client_toolkit::reexports::calloop;
+use std::{cell::RefCell, rc::Rc};
+use tracing::{Level, info, span};
 
 thread_local! {
     pub(crate) static ADAPTERS: RefCell<Vec<Rc<SpellSkiaWinAdapter>>> = const { RefCell::new(Vec::new()) };
@@ -112,6 +109,8 @@ impl SpellMultiWinHandler {
 pub struct SpellLockShell {
     /// An instance of [SpellMultiWinHandler].
     pub window_manager: Rc<RefCell<SpellMultiWinHandler>>,
+    /// Channel to allow executing functions in the slint event loop immediately
+    pub slint_event_sender: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
     /// Span storing the logging context for `debug`` statements of slint for
     /// lock screens.
     pub span: span::Span,
@@ -120,8 +119,12 @@ pub struct SpellLockShell {
 impl SpellLockShell {
     /// Internal function that creates an instance of layer implementation given
     /// [`SpellMultiWinHandler`] wrapped in smart pointers.
-    pub fn new(window_manager: Rc<RefCell<SpellMultiWinHandler>>) -> Self {
+    pub fn new(
+        window_manager: Rc<RefCell<SpellMultiWinHandler>>,
+        slint_event_sender: calloop::channel::Sender<Box<dyn FnOnce() + Send>>,
+    ) -> Self {
         SpellLockShell {
+            slint_event_sender,
             window_manager,
             span: span!(Level::INFO, "slint-lock-log",),
         }
@@ -132,6 +135,10 @@ impl Platform for SpellLockShell {
     fn create_window_adapter(&self) -> Result<Rc<dyn WindowAdapter>, slint::PlatformError> {
         let value = self.window_manager.borrow_mut().request_new_lock();
         Ok(value)
+    }
+
+    fn new_event_loop_proxy(&self) -> Option<Box<dyn EventLoopProxy>> {
+        Some(Box::new(SlintEventProxy(self.slint_event_sender.clone())))
     }
 
     fn debug_log(&self, arguments: core::fmt::Arguments) {
@@ -145,8 +152,7 @@ impl Platform for SpellLockShell {
     }
 }
 
-#[allow(clippy::type_complexity)]
-struct SlintEventProxy(Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>>);
+struct SlintEventProxy(calloop::channel::Sender<Box<dyn FnOnce() + Send>>);
 
 impl EventLoopProxy for SlintEventProxy {
     fn quit_event_loop(&self) -> Result<(), i_slint_core::api::EventLoopError> {
@@ -157,11 +163,8 @@ impl EventLoopProxy for SlintEventProxy {
         &self,
         event: Box<dyn FnOnce() + Send>,
     ) -> Result<(), i_slint_core::api::EventLoopError> {
-        if let Ok(mut list_of_event) = self.0.try_lock() {
-            (*list_of_event).push(event);
-        } else {
-            warn!("Slint proxy event could not be processed");
-        }
-        Ok(())
+        self.0
+            .send(event)
+            .map_err(|_| i_slint_core::api::EventLoopError::EventLoopTerminated)
     }
 }

--- a/spell-framework/src/wayland_adapter.rs
+++ b/spell-framework/src/wayland_adapter.rs
@@ -34,7 +34,7 @@ use smithay_client_toolkit::{
     output::{self, OutputHandler, OutputState},
     reexports::{
         calloop::{
-            EventLoop, LoopHandle, RegistrationToken,
+            self, EventLoop, LoopHandle, RegistrationToken,
             channel::{self, Sender},
             timer::{TimeoutAction, Timer},
         },
@@ -183,15 +183,14 @@ impl SpellWin {
             last_cursor_enter_serial: None,
         };
 
-        #[allow(clippy::type_complexity)]
-        let slint_proxy: Arc<Mutex<Vec<Box<dyn FnOnce() + Send>>>> =
-            Arc::new(Mutex::new(Vec::new()));
+        let (slint_event_sender, slint_event_receiver) =
+            calloop::channel::channel::<Box<dyn FnOnce() + Send>>();
         let adapter_value: Rc<SpellSkiaWinAdapter> = SpellSkiaWinAdapter::new(
             Rc::new(RefCell::new(pool)),
             RefCell::new(primary_slot),
             window_conf.width,
             window_conf.height,
-            slint_proxy.clone(),
+            slint_event_sender,
         );
 
         ADAPTERS.with_borrow_mut(|v| v.push(adapter_value.clone()));
@@ -201,7 +200,7 @@ impl SpellWin {
                 warn!("Error setting slint platform: {err}");
             }
         });
-        set_event_sources(&event_loop, handle);
+        set_event_sources(&event_loop, handle, slint_event_receiver);
 
         let mut win = SpellWin {
             adapter: adapter_value,
@@ -959,7 +958,8 @@ impl SpellLock {
                 wayland_buffer
             })
             .collect();
-        let slint_proxy = Arc::new(Mutex::new(Vec::new()));
+        let (slint_event_sender, slint_event_receiver) =
+            calloop::channel::channel::<Box<dyn FnOnce() + Send>>();
         let pool: Rc<RefCell<SlotPool>> = Rc::new(RefCell::new(pool));
         let mut adapters: Vec<Rc<SpellSkiaWinAdapter>> = Vec::new();
         buffer_slots
@@ -971,7 +971,7 @@ impl SpellLock {
                     slot,
                     sizes[index].width,
                     sizes[index].height,
-                    slint_proxy.clone(),
+                    slint_event_sender.clone(),
                 );
                 adapters.push(adapter);
             });
@@ -982,6 +982,21 @@ impl SpellLock {
             size: sizes,
             wayland_buffer: buffers,
         });
+
+        spell_lock
+            .loop_handle
+            .insert_source(slint_event_receiver, |event, _, data| {
+                if let calloop::channel::Event::Msg(callback) = event {
+                    callback();
+
+                    if let Some(slint_part) = &data.slint_part {
+                        for adapter in &slint_part.adapters {
+                            adapter.request_redraw();
+                        }
+                    }
+                }
+            })
+            .unwrap();
 
         spell_lock.backspace = Some(
             spell_lock
@@ -1025,7 +1040,10 @@ impl SpellLock {
             .loop_handle
             .disable(&spell_lock.backspace.unwrap())
             .unwrap();
-        let _ = slint::platform::set_platform(Box::new(SpellLockShell::new(multi_handler)));
+        let _ = slint::platform::set_platform(Box::new(SpellLockShell::new(
+            multi_handler,
+            slint_event_sender,
+        )));
 
         WaylandSource::new(spell_lock.conn.clone(), event_queue)
             .insert(spell_lock.loop_handle.clone())

--- a/spell-framework/src/wayland_adapter.rs
+++ b/spell-framework/src/wayland_adapter.rs
@@ -66,7 +66,7 @@ use std::{
     os::unix::net::UnixListener,
     process::Command,
     rc::Rc,
-    sync::{Arc, Mutex, Once, OnceLock, RwLock},
+    sync::{Once, OnceLock, RwLock},
     thread,
     time::Duration,
 };
@@ -190,13 +190,14 @@ impl SpellWin {
             RefCell::new(primary_slot),
             window_conf.width,
             window_conf.height,
-            slint_event_sender,
         );
 
         ADAPTERS.with_borrow_mut(|v| v.push(adapter_value.clone()));
         SET_SLINT_PLATFORM.call_once(|| {
             trace!("Slint platform set");
-            if let Err(err) = slint::platform::set_platform(Box::new(SpellLayerShell::default())) {
+            if let Err(err) =
+                slint::platform::set_platform(Box::new(SpellLayerShell::new(slint_event_sender)))
+            {
                 warn!("Error setting slint platform: {err}");
             }
         });
@@ -971,7 +972,6 @@ impl SpellLock {
                     slot,
                     sizes[index].width,
                     sizes[index].height,
-                    slint_event_sender.clone(),
                 );
                 adapters.push(adapter);
             });

--- a/spell-framework/src/wayland_adapter/way_helper.rs
+++ b/spell-framework/src/wayland_adapter/way_helper.rs
@@ -5,11 +5,14 @@ use crate::{
 };
 use i_slint_core::items::MouseCursor;
 use nonstick::{ConversationAdapter, Result as PamResult};
-use slint::{SharedString, platform::Key};
+use slint::{
+    SharedString,
+    platform::{Key, WindowAdapter},
+};
 use smithay_client_toolkit::{
     reexports::{
         calloop::{
-            EventLoop,
+            self, EventLoop,
             timer::{TimeoutAction, Timer},
         },
         client::{
@@ -175,7 +178,11 @@ impl PointerState {
     }
 }
 
-pub(crate) fn set_event_sources(event_loop: &EventLoop<'static, SpellWin>, handle: HomeHandle) {
+pub(crate) fn set_event_sources(
+    event_loop: &EventLoop<'static, SpellWin>,
+    handle: HomeHandle,
+    slint_event_receiver: calloop::channel::Channel<Box<dyn FnOnce() + Send>>,
+) {
     // let backspace_event = event_loop
     //     .handle()
     //     .insert_source(
@@ -267,24 +274,12 @@ pub(crate) fn set_event_sources(event_loop: &EventLoop<'static, SpellWin>, handl
 
     event_loop
         .handle()
-        .insert_source(
-            Timer::from_duration(Duration::from_millis(1000)),
-            |_, _, data| {
-                let slint_event_proxy = data.adapter.slint_event_proxy.clone();
-                if let Ok(mut list_of_events) = slint_event_proxy.try_lock()
-                    && !(*list_of_events).is_empty()
-                {
-                    let original_len = (*list_of_events).len();
-                    let mut x = 0;
-                    while x < original_len {
-                        let event = (*list_of_events).pop().unwrap();
-                        event();
-                        x += 1;
-                    }
-                }
-                TimeoutAction::ToDuration(Duration::from_millis(1000))
-            },
-        )
+        .insert_source(slint_event_receiver, |event, _, data| {
+            if let calloop::channel::Event::Msg(callback) = event {
+                callback();
+                data.adapter.request_redraw();
+            }
+        })
         .unwrap();
 }
 


### PR DESCRIPTION
Hi,

I ran into an issue where callbacks scheduled through Slint’s event-loop proxy could be delayed unpredictably.
Previously, callbacks passed to `invoke_from_event_loop` (or `Weak::upgrade_in_event_loop`) were stored in a `Mutex<Vec<Box<dyn FnOnce() + Send>>>` and then drained by a periodic timer, or when unrelated event-loop activity happened to occur. This meant callbacks could execute anywhere from almost immediately to close to the timer interval (1000ms) later.

This PR changes the callback dispatch to use a `calloop` channel instead. The receiver is registered as an event source for both the layer-shell and lock-shell event loops, so sending a callback wakes the event loop directly and executes the callback on the UI thread as soon as it can be dispatched. 

This removes the previous polling-based latency and makes event-loop callback execution much more predictable.

LMK if there's any changes you'd like to see.