### PR TITLE
fix pointer not being dispatched to slint on startup

### DIFF
--- a/spell-framework/src/wayland_adapter/win_impl.rs
+++ b/spell-framework/src/wayland_adapter/win_impl.rs
@@ -301,9 +301,24 @@ impl PointerHandler for SpellWin {
                     );
 
                     self.states.pointer_state.last_cursor_enter_serial = Some(serial);
+
+                    // PointerMoved feeds the initial cursor state to slint when it enters the window.
+                    // This ensures slint receives the correct cursor state on startup.
+                    self.adapter
+                        .as_ref()
+                        .unwrap()
+                        .try_dispatch_event(WindowEvent::PointerMoved {
+                            position: slint::LogicalPosition {
+                                x: event.position.0 as f32,
+                                y: event.position.1 as f32,
+                            },
+                        })
+                        .unwrap_or_else(|err| {
+                            warn!("Pointer enter event failed with error: {:?}", err)
+                        });
                 }
                 Leave { .. } => {
-                    info!("Pointer left: {:?}", event.position);
+                    trace!("Pointer left: {:?}", event.position);
                     self.adapter
                         .as_ref()
                         .unwrap()


### PR DESCRIPTION
fixes #28 

I think it also fixes #29, please review.

It sends a pointer moved event when entering the window to notify slint about the cursor position.

https://github.com/user-attachments/assets/b8ef1b7a-ae12-4d21-a7f0-dbc6c604f452

Let me know if you would like a function to be created for the pointer move event.
