### PR TITLE
fix mouse interactions being limited to LMB

### DIFF
--- a/spell-demo/src/bin/mouse_interactions.rs
+++ b/spell-demo/src/bin/mouse_interactions.rs
@@ -3,8 +3,10 @@
 //! This example creates a window with rectangles for each different mouse cursor type.
 //! Hovering over each rectangle should change the cursor to the corresponding shape,
 //! allowing visual verification that the Wayland cursor implementation works correctly.
+//! It also demonstrates how each mouse button press (left, right, middle)
+//! is registered and reported.
 //!
-//! Run with: cargo run -p spell-demo --bin cursor_test
+//! Run with: cargo run -p spell-demo --bin mouse_interactions
 
 use std::error::Error;
 
@@ -40,8 +42,54 @@ slint::slint! {
         }
     }
 
+    component MouseButtonTile inherits Rectangle {
+        in property <string> label;
+        in property <PointerEventButton> button-type;
+        out property <bool> pressed: false;
+
+        width: 120px;
+        height: 60px;
+        border-radius: 8px;
+        background: root.pressed ? #e05a47 : (ta.has-hover ? #4a90d9 : #2d4a6a);
+        border-width: 2px;
+        border-color: root.pressed ? #f57b6c : (ta.has-hover ? #7ab8f0 : #3d5a7a);
+
+        animate background { duration: 100ms; }
+        animate border-color { duration: 100ms; }
+
+        ta := TouchArea {
+            pointer-event(event) => {
+                if (event.button == root.button-type) {
+                    if (event.kind == PointerEventKind.down) {
+                        root.pressed = true;
+                    } else if (event.kind == PointerEventKind.up) {
+                        root.pressed = false;
+                    }
+                }
+            }
+        }
+
+        VerticalBox {
+            alignment: center;
+            spacing: 2px;
+            Text {
+                text: root.label;
+                color: #ffffff;
+                font-size: 11px;
+                font-weight: 700;
+                horizontal-alignment: center;
+            }
+            Text {
+                text: root.pressed ? "Pressed" : "Released";
+                color: root.pressed ? #ffcccc : #cccccc;
+                font-size: 10px;
+                horizontal-alignment: center;
+            }
+        }
+    }
+
     export component CursorTest inherits Window {
-        title: "Cursor Test - Hover to Test Each Cursor";
+        title: "Cursor & Mouse Interaction Test";
         background: #1a2a3a;
 
         ScrollView {
@@ -50,6 +98,34 @@ slint::slint! {
             VerticalBox {
                 padding: 20px;
                 spacing: 10px;
+
+                Text {
+                    text: "Mouse Interaction Test - Click with different mouse buttons";
+                    color: #ffffff;
+                    font-size: 16px;
+                    horizontal-alignment: center;
+                }
+
+                HorizontalBox {
+                    spacing: 8px;
+                    alignment: center;
+                    MouseButtonTile { label: "Left Button"; button-type: left; }
+                    MouseButtonTile { label: "Right Button"; button-type: right; }
+                    MouseButtonTile { label: "Middle Button"; button-type: middle; }
+                }
+
+                HorizontalBox {
+                    spacing: 8px;
+                    alignment: center;
+                    MouseButtonTile { label: "Back Button"; button-type: back; }
+                    MouseButtonTile { label: "Forward Button"; button-type: forward; }
+                    MouseButtonTile { label: "Other Button"; button-type: other; }
+                }
+
+                Rectangle {
+                    height: 2px;
+                    background: #3d5a7a;
+                }
 
                 Text {
                     text: "Cursor Test - Hover over each tile to test cursor shapes";
@@ -142,7 +218,7 @@ spell_framework::generate_widgets![CursorTest];
 fn main() -> Result<(), Box<dyn Error>> {
     let window_conf = WindowConf::builder()
         .width(560u32)
-        .height(520u32)
+        .height(720u32)
         .anchor_1(LayerAnchor::TOP)
         .margins(50, 0, 0, 0)
         .layer_type(LayerType::Top)

--- a/spell-framework/src/wayland_adapter.rs
+++ b/spell-framework/src/wayland_adapter.rs
@@ -77,6 +77,7 @@ pub use widget_impls::lock_impl::SpellSlintLock;
 
 mod fractional_scaling;
 mod slint_to_wl_cursor_mapping;
+mod smithay_to_slint_mouse_button_mapping;
 mod viewporter;
 mod way_helper;
 mod widget_impls;

--- a/spell-framework/src/wayland_adapter.rs
+++ b/spell-framework/src/wayland_adapter.rs
@@ -76,8 +76,8 @@ use tracing::{Level, info, span, trace, warn};
 pub use widget_impls::lock_impl::SpellSlintLock;
 
 mod fractional_scaling;
+mod pointer_button;
 mod slint_to_wl_cursor_mapping;
-mod smithay_to_slint_mouse_button_mapping;
 mod viewporter;
 mod way_helper;
 mod widget_impls;

--- a/spell-framework/src/wayland_adapter/pointer_button.rs
+++ b/spell-framework/src/wayland_adapter/pointer_button.rs
@@ -1,6 +1,6 @@
 use i_slint_core::items::PointerEventButton;
 
-// Uses the official evdev mouse button codes defined in:
+// Uses the official evdev pointer button codes defined in:
 // https://github.com/torvalds/linux/blob/8e65320d91cdc3b241d4b94855c88459b91abf66/include/uapi/linux/input-event-codes.h#L357-L361
 const BTN_LEFT: u32 = 0x110;
 const BTN_RIGHT: u32 = 0x111;
@@ -10,8 +10,8 @@ const BTN_EXTRA: u32 = 0x114;
 const BTN_FORWARD: u32 = 0x115;
 const BTN_BACK: u32 = 0x116;
 
-/// Maps evdev mouse button codes to the Slint [PointerEventButton] enum.
-pub fn map_mouse_button(button: u32) -> PointerEventButton {
+/// Maps evdev pointer button codes to the Slint [PointerEventButton] enum.
+pub fn map_pointer_button(button: u32) -> PointerEventButton {
     match button {
         BTN_LEFT => PointerEventButton::Left,
         BTN_RIGHT => PointerEventButton::Right,

--- a/spell-framework/src/wayland_adapter/smithay_to_slint_mouse_button_mapping.rs
+++ b/spell-framework/src/wayland_adapter/smithay_to_slint_mouse_button_mapping.rs
@@ -1,0 +1,23 @@
+use i_slint_core::items::PointerEventButton;
+
+// Uses the official evdev mouse button codes defined in:
+// https://github.com/torvalds/linux/blob/8e65320d91cdc3b241d4b94855c88459b91abf66/include/uapi/linux/input-event-codes.h#L357-L361
+const BTN_LEFT: u32 = 0x110;
+const BTN_RIGHT: u32 = 0x111;
+const BTN_MIDDLE: u32 = 0x112;
+const BTN_SIDE: u32 = 0x113;
+const BTN_EXTRA: u32 = 0x114;
+const BTN_FORWARD: u32 = 0x115;
+const BTN_BACK: u32 = 0x116;
+
+/// Maps evdev mouse button codes to the Slint [PointerEventButton] enum.
+pub fn map_mouse_button(button: u32) -> PointerEventButton {
+    match button {
+        BTN_LEFT => PointerEventButton::Left,
+        BTN_RIGHT => PointerEventButton::Right,
+        BTN_MIDDLE => PointerEventButton::Middle,
+        BTN_SIDE | BTN_BACK => PointerEventButton::Back,
+        BTN_EXTRA | BTN_FORWARD => PointerEventButton::Forward,
+        _ => PointerEventButton::Other,
+    }
+}

--- a/spell-framework/src/wayland_adapter/widget_impls/win_impl.rs
+++ b/spell-framework/src/wayland_adapter/widget_impls/win_impl.rs
@@ -1,10 +1,7 @@
 use crate::wayland_adapter::{
-    SpellWin, smithay_to_slint_mouse_button_mapping::map_mouse_button, way_helper::get_string,
+    SpellWin, pointer_button::map_pointer_button, way_helper::get_string,
 };
-use slint::{
-    SharedString,
-    platform::{PointerEventButton, WindowEvent},
-};
+use slint::{SharedString, platform::WindowEvent};
 use smithay_client_toolkit::{
     output::OutputState,
     reexports::client::{
@@ -376,7 +373,7 @@ impl PointerHandler for SpellWin {
                                 x: event.position.0 as f32,
                                 y: event.position.1 as f32,
                             },
-                            button: map_mouse_button(button),
+                            button: map_pointer_button(button),
                         })
                         .unwrap_or_else(|err| {
                             warn!("Pointer press event failed with error: {:?}", err)
@@ -393,7 +390,7 @@ impl PointerHandler for SpellWin {
                                 x: event.position.0 as f32,
                                 y: event.position.1 as f32,
                             },
-                            button: map_mouse_button(button),
+                            button: map_pointer_button(button),
                         })
                         .unwrap_or_else(|err| {
                             warn!("Pointer release event failed with error: {:?}", err)

--- a/spell-framework/src/wayland_adapter/widget_impls/win_impl.rs
+++ b/spell-framework/src/wayland_adapter/widget_impls/win_impl.rs
@@ -342,7 +342,7 @@ impl PointerHandler for SpellWin {
                     self.states.pointer_state.last_cursor_enter_serial = Some(serial);
                 }
                 Leave { .. } => {
-                    info!("Pointer left: {:?}", event.position);
+                    trace!("Pointer left: {:?}", event.position);
                     self.adapter
                         .as_ref()
                         .unwrap()

--- a/spell-framework/src/wayland_adapter/widget_impls/win_impl.rs
+++ b/spell-framework/src/wayland_adapter/widget_impls/win_impl.rs
@@ -1,4 +1,6 @@
-use crate::wayland_adapter::{SpellWin, way_helper::get_string};
+use crate::wayland_adapter::{
+    SpellWin, smithay_to_slint_mouse_button_mapping::map_mouse_button, way_helper::get_string,
+};
 use slint::{
     SharedString,
     platform::{PointerEventButton, WindowEvent},
@@ -365,7 +367,7 @@ impl PointerHandler for SpellWin {
                         });
                 }
                 Press { button, .. } => {
-                    trace!("Press {:x} @ {:?}", button, event.position);
+                    trace!("Press {:?} @ {:?}", button, event.position);
                     self.adapter
                         .as_ref()
                         .unwrap()
@@ -374,14 +376,15 @@ impl PointerHandler for SpellWin {
                                 x: event.position.0 as f32,
                                 y: event.position.1 as f32,
                             },
-                            button: PointerEventButton::Left,
+                            button: map_mouse_button(button),
                         })
                         .unwrap_or_else(|err| {
                             warn!("Pointer press event failed with error: {:?}", err)
                         });
                 }
                 Release { button, .. } => {
-                    trace!("Release {:x} @ {:?}", button, event.position);
+                    trace!("Release {:?} @ {:?}", button, event.position);
+
                     self.adapter
                         .as_ref()
                         .unwrap()
@@ -390,7 +393,7 @@ impl PointerHandler for SpellWin {
                                 x: event.position.0 as f32,
                                 y: event.position.1 as f32,
                             },
-                            button: PointerEventButton::Left,
+                            button: map_mouse_button(button),
                         })
                         .unwrap_or_else(|err| {
                             warn!("Pointer release event failed with error: {:?}", err)


### PR DESCRIPTION
Adds support between hardware key codes & the slint key enum.
Via this way we can use all 5 (6 if we include other) mouse buttons that can be used in Slint.

I've added 6 buttons to test the interactinos & renamed cursor_test to mouse_interactions to more accuratly reflect the usage.
--- 
Fixes #32 

https://github.com/user-attachments/assets/2c49c321-970f-4f06-b6c7-2d36229a04c7

