### PR TITLE
Fix notification events

### DIFF
--- a/spell-framework/src/vault.rs
+++ b/spell-framework/src/vault.rs
@@ -19,10 +19,10 @@ use std::{
     path::{Component, Path, PathBuf},
     sync::OnceLock,
 };
-use zbus::blocking::{Connection, Proxy};
 
 mod application;
 mod notification_manager;
+
 
 /// This public static is only set when a notification server instance is passed in
 /// [`cast_spell`](crate::cast_spell).
@@ -32,6 +32,28 @@ mod notification_manager;
 /// with an id has been closed. This static holds an instance of
 /// [`BlockingNotificaiton`](crate::vault::BlockingNotification)
 pub static NOTIFICATION_EVENT: OnceLock<BlockingNotification> = OnceLock::new();
+
+/// Event enum used to route notification signals back to the primary dbus thread.
+pub enum DbusSignalEvent {
+    /// Sent when an action is triggered.
+    ActionInvoked { 
+        /// The id of the notification.
+        id: u32, 
+        /// The specific action key associated with the specyfic action,
+        action_key: String 
+    },
+    /// Sent when a notification is closed.
+    NotificationClosed { 
+        /// The id of the notification.
+        id: u32, 
+        /// The reason for the notification being closed.
+        reason: u32 
+    },
+}
+
+/// Channel to send notification events to the main dbus thread.
+/// Events need to be sent from the main dbus thread that is authenticated as "/org/freedesktop/Notifications" or dbus will reject them.
+pub static DBUS_SIGNAL_SENDER: OnceLock<tokio::sync::mpsc::UnboundedSender<DbusSignalEvent>> = OnceLock::new();
 
 /// Holds blocking methods to notify when a notification has bee closed.
 #[derive(Default)]
@@ -44,31 +66,29 @@ impl BlockingNotification {
         id: u32,
         reason: CloseReason,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let conn = Connection::session()?;
-        let proxy = Proxy::new(
-            &conn,
-            "org.freedesktop.Notifications",
-            "/org/freedesktop/Notifications",
-            "org.freedesktop.Notifications",
-        )?;
-        proxy.call_noreply("NotificationClosed", &(id, reason as u32))?;
+        tracing::info!("Close triggered for ID: {}, Reason: {:?}", id, reason);
+        
+        if let Some(tx) = DBUS_SIGNAL_SENDER.get() {
+            let _ = tx.send(DbusSignalEvent::NotificationClosed { id, reason: reason as u32 });
+        } else {
+            tracing::error!("DBUS_SIGNAL_SENDER is not initialized!");
+        }
         Ok(())
     }
 
     /// Calls an action to the owner application of the notification via a dbus signal.
     pub fn action_invoked(
         &self,
-        id: i32,
+        id: u32,
         action_key: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let conn = Connection::session()?;
-        let proxy = Proxy::new(
-            &conn,
-            "org.freedesktop.Notifications",
-            "/org/freedesktop/Notifications",
-            "org.freedesktop.Notifications",
-        )?;
-        proxy.call_noreply("ActionInvoked", &(id, action_key))?;
+        tracing::info!("Action triggered for ID: {}, Action Key: '{}'", id, action_key);
+
+        if let Some(tx) = DBUS_SIGNAL_SENDER.get() {
+            let _ = tx.send(DbusSignalEvent::ActionInvoked { id, action_key: action_key.to_string() });
+        } else {
+            tracing::error!("DBUS_SIGNAL_SENDER is not initialized!");
+        }
         Ok(())
     }
 }

--- a/spell-framework/src/vault.rs
+++ b/spell-framework/src/vault.rs
@@ -51,15 +51,17 @@ pub enum DbusSignalEvent {
     },
 }
 
-/// Channel to send notification events to the main dbus thread.
-/// Events need to be sent from the main dbus thread that is authenticated as "/org/freedesktop/Notifications" or dbus will reject them.
-pub static DBUS_SIGNAL_SENDER: OnceLock<tokio::sync::mpsc::UnboundedSender<DbusSignalEvent>> = OnceLock::new();
-
 /// Holds blocking methods to notify when a notification has bee closed.
-#[derive(Default)]
-pub struct BlockingNotification;
+pub struct BlockingNotification {
+    sender: tokio::sync::mpsc::UnboundedSender<DbusSignalEvent>,
+}
 
 impl BlockingNotification {
+    /// Constructor accepting the sender as a formal parameter.
+    pub fn new(sender: tokio::sync::mpsc::UnboundedSender<DbusSignalEvent>) -> Self {
+        Self { sender }
+    }
+
     /// Method to ask the server to emit a signal for closing a particular notificaiton.
     pub fn call_close(
         &self,
@@ -68,11 +70,7 @@ impl BlockingNotification {
     ) -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("Close triggered for ID: {}, Reason: {:?}", id, reason);
         
-        if let Some(tx) = DBUS_SIGNAL_SENDER.get() {
-            let _ = tx.send(DbusSignalEvent::NotificationClosed { id, reason: reason as u32 });
-        } else {
-            tracing::error!("DBUS_SIGNAL_SENDER is not initialized!");
-        }
+        let _ = self.sender.send(DbusSignalEvent::NotificationClosed { id, reason: reason as u32 });
         Ok(())
     }
 
@@ -84,11 +82,7 @@ impl BlockingNotification {
     ) -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("Action triggered for ID: {}, Action Key: '{}'", id, action_key);
 
-        if let Some(tx) = DBUS_SIGNAL_SENDER.get() {
-            let _ = tx.send(DbusSignalEvent::ActionInvoked { id, action_key: action_key.to_string() });
-        } else {
-            tracing::error!("DBUS_SIGNAL_SENDER is not initialized!");
-        }
+        let _ = self.sender.send(DbusSignalEvent::ActionInvoked { id, action_key: action_key.to_string() });
         Ok(())
     }
 }

--- a/spell-framework/src/vault/notification_manager.rs
+++ b/spell-framework/src/vault/notification_manager.rs
@@ -1,6 +1,6 @@
 use crate::{
     vault::{
-        BlockingNotification, DBUS_SIGNAL_SENDER, DbusSignalEvent, Hint, NOTIFICATION_EVENT, Notification, NotificationManager, Timeout, Urgency,
+        BlockingNotification, DbusSignalEvent, Hint, NOTIFICATION_EVENT, Notification, NotificationManager, Timeout, Urgency,
     }, wayland_adapter::SpellWin,
 };
 use smithay_client_toolkit::reexports::calloop::channel::{self, Sender};
@@ -14,6 +14,9 @@ pub fn set_notification(win: &SpellWin, ui: Box<dyn NotificationManager>) {
     let (sender, rx) = channel::channel::<NotifyEvent>();
     // let (sender_async, rx_async) = channel::channel::<NotifyEvent>();
     // NOTIFICATION_EVENT.get_or_init(|| sender_async);
+    
+    let (tx, dbus_rx) = tokio::sync::mpsc::unbounded_channel::<DbusSignalEvent>();
+
     let layer_name = win.layer_name.clone();
     let sender_cl = sender.clone();
     std::thread::spawn(move || {
@@ -23,11 +26,11 @@ pub fn set_notification(win: &SpellWin, ui: Box<dyn NotificationManager>) {
             .unwrap();
         rt.block_on(async move {
             //TODO handle and report the error here
-            let _ = notification_service_enter(sender_cl, layer_name).await;
+            let _ = notification_service_enter(sender_cl, layer_name, dbus_rx).await;
         });
     });
 
-    let _ = NOTIFICATION_EVENT.set(BlockingNotification);
+    let _ = NOTIFICATION_EVENT.set(BlockingNotification::new(tx));
     let _ = win
         .loop_handle
         .clone()
@@ -56,6 +59,7 @@ pub(crate) enum NotifyEvent {
 async fn notification_service_enter(
     sender: Sender<NotifyEvent>,
     layer_name: String,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<DbusSignalEvent>,
 ) -> zbus::fdo::Result<()> {
     let conn = zbus::Connection::session().await?;
     conn.object_server()
@@ -74,9 +78,6 @@ async fn notification_service_enter(
         warn!("Error When creating notification crate {:?}", err);
     }
     info!("Notification service is live with the provided name");
-
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DbusSignalEvent>();
-    let _ = DBUS_SIGNAL_SENDER.set(tx);
 
     while let Some(event) = rx.recv().await {
         if let Ok(iface_ref) = conn

--- a/spell-framework/src/vault/notification_manager.rs
+++ b/spell-framework/src/vault/notification_manager.rs
@@ -1,9 +1,7 @@
 use crate::{
     vault::{
-        BlockingNotification, Hint, NOTIFICATION_EVENT, Notification, NotificationManager, Timeout,
-        Urgency,
-    },
-    wayland_adapter::SpellWin,
+        BlockingNotification, DBUS_SIGNAL_SENDER, DbusSignalEvent, Hint, NOTIFICATION_EVENT, Notification, NotificationManager, Timeout, Urgency,
+    }, wayland_adapter::SpellWin,
 };
 use smithay_client_toolkit::reexports::calloop::channel::{self, Sender};
 use std::{cmp::Ordering, collections::HashMap};
@@ -82,7 +80,28 @@ async fn notification_service_enter(
         warn!("Error When creating notification crate {:?}", err);
     }
     info!("Notification service is live with the provided name");
-    std::future::pending::<()>().await;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<DbusSignalEvent>();
+    let _ = DBUS_SIGNAL_SENDER.set(tx);
+
+    while let Some(event) = rx.recv().await {
+        if let Ok(iface_ref) = conn
+            .object_server()
+            .interface::<_, NotificationHandler>("/org/freedesktop/Notifications")
+            .await
+        {
+            let emitter = iface_ref.signal_emitter();
+            match event {
+                DbusSignalEvent::ActionInvoked { id, action_key } => {
+                    let _ = NotificationHandler::action_invoked(&emitter, id, &action_key).await;
+                }
+                DbusSignalEvent::NotificationClosed { id, reason } => {
+                    let _ = NotificationHandler::notification_closed(&emitter, id, reason).await;
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #36 by routing events to be sent through the main dbus thread this is needed because dbus ignores events from threads that arent registered as the notification server.
I have tested it and it works are the changes fine or should I change something?